### PR TITLE
[FIX] Remove mysqlclient from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 sqlalchemy
-mysqlclient
 pymssql


### PR DESCRIPTION
This causes builds on Odoo.sh to fail and it is not needed for our project.